### PR TITLE
chore(ci): add PR CI and Open VSX publish workflows

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -31,4 +31,4 @@ jobs:
         run: bun run lint
 
       - name: Unit tests
-        run: bun test src/lib/
+        run: bun run test

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,34 @@
+name: PR CI (ts-check, lint, test)
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: pr-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.2.19
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: TypeScript check
+        run: bun run ts
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Unit tests
+        run: bun test src/lib/

--- a/.github/workflows/publish-open-vsx.yml
+++ b/.github/workflows/publish-open-vsx.yml
@@ -1,0 +1,56 @@
+name: Test and Publish (Open VSX)
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: publish-open-vsx-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Run lint and unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.2.19
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        run: bun run test
+
+  publish_open_vsx:
+    name: Publish to Open VSX
+    needs: test
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.2.19
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run compile
+
+      - name: Publish
+        env:
+          OPEN_VSX_TOKEN: ${{ secrets.OPEN_VSX_TOKEN }}
+        run: bunx --bun ovsx publish -p "$OPEN_VSX_TOKEN"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "lint": "oxlint --fix",
     "test:e2e": "node ./out/test/runTest.js",
     "test": "bun test src/lib/",
+    "ts": "tsc --noEmit",
     "package": "bun vsce package --no-dependencies",
     "publish": "bun vsce publish --no-dependencies"
   },


### PR DESCRIPTION
**JIRA card**
[letsdeel.atlassian.net/browse/ITPL-XXX](https://letsdeel.atlassian.net/browse/ITPL-343)

**Description**

Add CI workflows to validate PRs and publish the extension to Open VSX on merge to main.

Changes:
- Add PR CI workflow to run TypeScript checks, lint and unit tests using Bun
- Add publish workflow to build and publish to Open VSX when merging to main
- Use Bun 1.2.19 with frozen lockfile installs

**Examples:**
- PR CI will run on this PR
- Publish workflow will run after this PR is merged into `main` (requires `OPEN_VSX_TOKEN` secret)
